### PR TITLE
refactor: レートリミット情報をOAuth APIからstdin rate_limitsに移行

### DIFF
--- a/ClaudeCode/scripts/statusline.py
+++ b/ClaudeCode/scripts/statusline.py
@@ -18,6 +18,7 @@ import argparse
 import contextlib
 import json
 import locale
+import math
 import os
 import subprocess
 import sys
@@ -764,11 +765,16 @@ def _seg_rate_common(
 
     pct_val = _safe_float(bucket.get("used_percentage"))
     ts = _safe_float(bucket.get("resets_at"))
-    if pct_val is None or ts is None:
+    if (
+        pct_val is None
+        or ts is None
+        or not math.isfinite(pct_val)
+        or not math.isfinite(ts)
+    ):
         return None
     try:
         reset_str = fmt_reset(ts)
-    except ValueError, TypeError:
+    except ValueError, TypeError, OverflowError, OSError:
         return None
 
     color = _color_for_utilization(pct_val)

--- a/ClaudeCode/scripts/statusline.py
+++ b/ClaudeCode/scripts/statusline.py
@@ -838,7 +838,7 @@ def _seg_rate_common(
     fmt_reset: Callable[[int | float], str],
 ) -> Segment | None:
     """レートリミットセグメントの共通生成ロジック"""
-    usage = data.get("_usage")
+    usage = data.get("rate_limits")
     if not isinstance(usage, dict):
         return None
 
@@ -846,7 +846,7 @@ def _seg_rate_common(
     if not isinstance(bucket, dict):
         return None
 
-    pct_val = _safe_float(bucket.get("utilization"))
+    pct_val = _safe_float(bucket.get("used_percentage"))
     ts = _safe_float(bucket.get("resets_at"))
     if pct_val is None or ts is None:
         return None

--- a/ClaudeCode/scripts/statusline.py
+++ b/ClaudeCode/scripts/statusline.py
@@ -225,23 +225,15 @@ def _color_for_utilization(pct: float) -> _Color:
     return _Color.GREEN
 
 
-def _parse_iso_to_local(iso_str: str) -> datetime:
-    """ISO 8601文字列をローカルタイムゾーンのdatetimeに変換する"""
-    dt = datetime.fromisoformat(iso_str)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=UTC)
-    return dt.astimezone()
-
-
-def _format_reset_time_short(iso_str: str) -> str:
+def _format_reset_time_short(ts: float) -> str:
     """リセット時刻を "H:MM" 形式でフォーマットする(0埋めなし)"""
-    local_dt = _parse_iso_to_local(iso_str)
+    local_dt = datetime.fromtimestamp(ts, tz=UTC).astimezone()
     return f"{local_dt.hour}:{local_dt.minute:02d}"
 
 
-def _format_reset_date(iso_str: str) -> str:
+def _format_reset_date(ts: float) -> str:
     """リセット時刻を "M/D H:MM" 形式でフォーマットする(0埋めなし)"""
-    local_dt = _parse_iso_to_local(iso_str)
+    local_dt = datetime.fromtimestamp(ts, tz=UTC).astimezone()
     return f"{local_dt.month}/{local_dt.day} {local_dt.hour}:{local_dt.minute:02d}"
 
 
@@ -843,7 +835,7 @@ def _seg_rate_common(
     usage_key: str,
     period_label: str,
     icon: str,
-    fmt_reset: Callable[[str], str],
+    fmt_reset: Callable[[int | float], str],
 ) -> Segment | None:
     """レートリミットセグメントの共通生成ロジック"""
     usage = data.get("_usage")
@@ -854,12 +846,12 @@ def _seg_rate_common(
     if not isinstance(bucket, dict):
         return None
 
-    resets_at = bucket.get("resets_at")
     pct_val = _safe_float(bucket.get("utilization"))
-    if pct_val is None or resets_at is None:
+    ts = _safe_float(bucket.get("resets_at"))
+    if pct_val is None or ts is None:
         return None
     try:
-        reset_str = fmt_reset(str(resets_at))
+        reset_str = fmt_reset(ts)
     except ValueError, TypeError:
         return None
 

--- a/ClaudeCode/scripts/statusline.py
+++ b/ClaudeCode/scripts/statusline.py
@@ -19,7 +19,6 @@ import contextlib
 import json
 import locale
 import os
-import platform
 import subprocess
 import sys
 import tempfile
@@ -82,9 +81,6 @@ class _Icons:
 
 
 _SEPARATOR = " \u2502 "  # " │ "
-_CACHE_TTL = 360  # 6分
-_CACHE_PATH = Path(tempfile.gettempdir()) / "claude-usage-cache.json"
-_API_URL = "https://api.anthropic.com/api/oauth/usage"
 _API_TIMEOUT = 5  # 秒
 _SUBPROCESS_TIMEOUT = 3  # 秒
 _GIT_CACHE_TTL = 5  # 秒
@@ -464,86 +460,6 @@ def _resolve_currency(currency_arg: str | None) -> str:
         return locale_currency
 
     return "USD"
-
-
-def _get_oauth_token() -> str | None:
-    """OAuth認証トークンを取得する
-
-    以下の順に試行する:
-    1. ~/.claude/.credentials.json からファイル読み取り(Windows/Linux)
-    2. macOSのKeychainから取得
-    """
-    # 1. クレデンシャルファイルから読む
-    cred_path = Path.home() / ".claude" / ".credentials.json"
-    with contextlib.suppress(
-        OSError, json.JSONDecodeError, KeyError, TypeError, AttributeError
-    ):
-        cred_text = cred_path.read_text(encoding="utf-8")
-        cred_data = json.loads(cred_text)
-        token = cred_data.get("claudeAiOauth", {}).get("accessToken")
-        if token:
-            return str(token)
-
-    # 2. macOS Keychainから取得
-    if platform.system() == "Darwin":
-        with contextlib.suppress(
-            subprocess.TimeoutExpired,
-            subprocess.SubprocessError,
-            json.JSONDecodeError,
-            KeyError,
-            TypeError,
-            OSError,
-        ):
-            result = subprocess.run(
-                [  # noqa: S607
-                    "security",
-                    "find-generic-password",
-                    "-s",
-                    "Claude Code-credentials",
-                    "-w",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=_SUBPROCESS_TIMEOUT,
-                check=False,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                keychain_data = json.loads(result.stdout.strip())
-                token = keychain_data.get("claudeAiOauth", {}).get("accessToken")
-                if token:
-                    return str(token)
-
-    return None
-
-
-def _fetch_usage(token: str) -> dict[str, Any]:
-    """Anthropic Usage APIからレートリミット情報を取得する"""
-    req = Request(
-        _API_URL,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "anthropic-beta": "oauth-2025-04-20",
-        },
-    )
-    with urlopen(req, timeout=_API_TIMEOUT) as resp:  # noqa: S310
-        body = resp.read().decode("utf-8")
-    return json.loads(body)
-
-
-def _get_usage() -> dict[str, Any] | None:
-    """キャッシュ付きでUsage APIからデータを取得する
-
-    キャッシュのTTLは_CACHE_TTL秒である
-    API呼び出しに失敗した場合、期限切れキャッシュも使用する
-    """
-
-    def fetch() -> dict[str, Any]:
-        token = _get_oauth_token()
-        if token is None:
-            raise RuntimeError
-        return _fetch_usage(token)
-
-    return _cached_fetch(_CACHE_PATH, _CACHE_TTL, fetch)
 
 
 def _get_cwd(data: dict[str, Any]) -> str:
@@ -1005,11 +921,6 @@ def main() -> None:
     git_info = _get_git_info(cwd) if cwd else None
     if git_info is not None:
         data["_git"] = git_info
-
-    # レートリミット情報を取得してdataに格納する
-    usage = _get_usage()
-    if usage is not None:
-        data["_usage"] = usage
 
     lines_config = _parse_segments(args.segments)
     lines = _build_lines(data, lines_config)

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1198,7 +1198,7 @@ class TestSegRateCommon:
 
     def test_missing_used_percentage_returns_none(self) -> None:
         """used_percentageがない場合はNone"""
-        data = {"rate_limits": {"five_hour": {"resets_at": "2025-01-15T14:30:00Z"}}}
+        data = {"rate_limits": {"five_hour": {"resets_at": 1736951400.0}}}
         seg = statusline._seg_rate_common(
             data, "five_hour", "5h", "\u23f0", statusline._format_reset_time_short
         )
@@ -1231,7 +1231,7 @@ class TestSegRateCommon:
             "rate_limits": {
                 "five_hour": {
                     "used_percentage": "abc",
-                    "resets_at": "2025-01-15T14:30:00Z",
+                    "resets_at": 1736951400.0,
                 },
             },
         }
@@ -1325,6 +1325,8 @@ class TestBuildLines:
         ):
             lines = statusline._build_lines(data)
         assert len(lines) == 3
+        assert "14:30" in lines[1]
+        assert "1/20 0:00" in lines[1]
 
     def test_minimal_data_returns_project_line(self) -> None:
         """最小データでもプロジェクト行は返る"""
@@ -1386,6 +1388,8 @@ class TestBuildLines:
         assert len(lines) == 3
         assert "myproject" in lines[0]  # workspace.current_dirが優先される
         assert "Opus 4.6" in lines[1]
+        assert "14:30" in lines[1]
+        assert "1/20 0:00" in lines[1]
         assert "$0.01" in lines[2]
 
 

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -82,6 +82,16 @@ _FULL_STDIN_SAMPLE: dict[str, Any] = {
         "original_cwd": "/path/to/project",
         "original_branch": "main",
     },
+    "rate_limits": {
+        "five_hour": {
+            "used_percentage": 42,
+            "resets_at": 1736949000,
+        },
+        "seven_day": {
+            "used_percentage": 66,
+            "resets_at": 1737331200,
+        },
+    },
 }
 
 
@@ -1296,14 +1306,14 @@ class TestBuildLines:
             },
             "model": {"display_name": "Opus", "id": "claude-opus-4-6"},
             "context_window": {"used_percentage": 45},
-            "_usage": {
+            "rate_limits": {
                 "five_hour": {
-                    "utilization": 30.0,
-                    "resets_at": "2025-01-15T14:30:00Z",
+                    "used_percentage": 30,
+                    "resets_at": 1736949000,
                 },
                 "seven_day": {
-                    "utilization": 50.0,
-                    "resets_at": "2025-01-20T00:00:00Z",
+                    "used_percentage": 50,
+                    "resets_at": 1737331200,
                 },
             },
             "cost": {"total_cost_usd": 1.23},
@@ -1368,9 +1378,11 @@ class TestBuildLines:
         with (
             patch.object(statusline, "_currency", "USD"),
             patch.object(statusline, "_SESSION_COST_CACHE_PATH", cache_path),
+            patch("statusline._format_reset_time_short", return_value="14:30"),
+            patch("statusline._format_reset_date", return_value="1/20 0:00"),
         ):
             lines = statusline._build_lines(dict(_FULL_STDIN_SAMPLE))
-        # stdinデータのみ(runtime注入なし)で3行: project, model+context, cost
+        # stdinデータのみ(runtime注入なし)で3行: project, model+context+rate, cost
         assert len(lines) == 3
         assert "myproject" in lines[0]  # workspace.current_dirが優先される
         assert "Opus 4.6" in lines[1]

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1389,142 +1389,6 @@ class TestBuildLines:
         assert "$0.01" in lines[2]
 
 
-class TestGetOauthToken:
-    """_get_oauth_token のテスト"""
-
-    def test_reads_from_credentials_file(self, tmp_path: Path) -> None:
-        """クレデンシャルファイルからトークンを読み取る"""
-        cred_dir = tmp_path / ".claude"
-        cred_dir.mkdir()
-        cred_file = cred_dir / ".credentials.json"
-        cred_file.write_text(
-            json.dumps({"claudeAiOauth": {"accessToken": "test-token-123"}})
-        )
-        with patch("statusline.Path.home", return_value=tmp_path):
-            result = statusline._get_oauth_token()
-        assert result == "test-token-123"
-
-    def test_no_credentials_file_returns_none(self, tmp_path: Path) -> None:
-        """クレデンシャルファイルが存在しない場合はNone(非macOS)"""
-        with (
-            patch("statusline.Path.home", return_value=tmp_path),
-            patch("statusline.platform.system", return_value="Windows"),
-        ):
-            result = statusline._get_oauth_token()
-        assert result is None
-
-    def test_invalid_json_returns_none(self, tmp_path: Path) -> None:
-        """JSONパース失敗時はNone(非macOS)"""
-        cred_dir = tmp_path / ".claude"
-        cred_dir.mkdir()
-        cred_file = cred_dir / ".credentials.json"
-        cred_file.write_text("not-json")
-        with (
-            patch("statusline.Path.home", return_value=tmp_path),
-            patch("statusline.platform.system", return_value="Windows"),
-        ):
-            result = statusline._get_oauth_token()
-        assert result is None
-
-    def test_missing_access_token_returns_none(self, tmp_path: Path) -> None:
-        """accessTokenがない場合はNone(非macOS)"""
-        cred_dir = tmp_path / ".claude"
-        cred_dir.mkdir()
-        cred_file = cred_dir / ".credentials.json"
-        cred_file.write_text(json.dumps({"claudeAiOauth": {}}))
-        with (
-            patch("statusline.Path.home", return_value=tmp_path),
-            patch("statusline.platform.system", return_value="Windows"),
-        ):
-            result = statusline._get_oauth_token()
-        assert result is None
-
-    def test_keychain_fallback_on_darwin(self, tmp_path: Path) -> None:
-        """macOSではKeychainにフォールバックする"""
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = json.dumps({
-            "claudeAiOauth": {"accessToken": "keychain-token"}
-        })
-        with (
-            patch("statusline.Path.home", return_value=tmp_path),
-            patch("statusline.platform.system", return_value="Darwin"),
-            patch("statusline.subprocess.run", return_value=mock_result),
-        ):
-            result = statusline._get_oauth_token()
-        assert result == "keychain-token"
-
-
-class TestFetchUsage:
-    """_fetch_usage のテスト"""
-
-    def test_fetches_from_api(self) -> None:
-        """APIからレスポンスを取得しパースする"""
-        mock_resp = _mock_http_response(b'{"five_hour":{"utilization":30}}')
-
-        with patch("statusline.urlopen", return_value=mock_resp):
-            result = statusline._fetch_usage("test-token")
-        assert result == {"five_hour": {"utilization": 30}}
-
-    def test_sets_authorization_header(self) -> None:
-        """Authorizationヘッダーを設定する"""
-        mock_resp = _mock_http_response(b"{}")
-
-        with patch("statusline.urlopen", return_value=mock_resp) as mock_urlopen:
-            statusline._fetch_usage("my-secret-token")
-
-        req = mock_urlopen.call_args[0][0]
-        assert req.get_header("Authorization") == "Bearer my-secret-token"
-
-    def test_network_error_raises(self) -> None:
-        """ネットワークエラー時は例外を送出する"""
-        with (
-            patch("statusline.urlopen", side_effect=URLError("fail")),
-            pytest.raises(URLError, match="fail"),
-        ):
-            statusline._fetch_usage("token")
-
-
-class TestGetUsage:
-    """_get_usage のテスト"""
-
-    def test_returns_data_from_api(self, tmp_path: Path) -> None:
-        """APIからデータを取得して返す"""
-        cache_file = tmp_path / "usage-cache.json"
-        with (
-            patch.object(statusline, "_CACHE_PATH", cache_file),
-            patch("statusline._get_oauth_token", return_value="test-token"),
-            patch(
-                "statusline._fetch_usage",
-                return_value={"five_hour": {"utilization": 30}},
-            ),
-        ):
-            result = statusline._get_usage()
-        assert result == {"five_hour": {"utilization": 30}}
-
-    def test_returns_none_when_no_token(self, tmp_path: Path) -> None:
-        """トークン取得失敗時はNone"""
-        cache_file = tmp_path / "nonexistent.json"
-        with (
-            patch.object(statusline, "_CACHE_PATH", cache_file),
-            patch("statusline._get_oauth_token", return_value=None),
-        ):
-            result = statusline._get_usage()
-        assert result is None
-
-    def test_returns_cached_data(self, tmp_path: Path) -> None:
-        """有効なキャッシュがあればAPIを呼ばず返す"""
-        cache_file = tmp_path / "usage-cache.json"
-        cache_data = {
-            "_cached_at": time.time(),
-            "data": {"five_hour": {"utilization": 25}},
-        }
-        cache_file.write_text(json.dumps(cache_data))
-        with patch.object(statusline, "_CACHE_PATH", cache_file):
-            result = statusline._get_usage()
-        assert result == {"five_hour": {"utilization": 25}}
-
-
 class TestFetchGitInfo:
     """_fetch_git_info のテスト"""
 
@@ -1910,7 +1774,6 @@ class TestMain:
             patch("sys.stdin") as mock_stdin,
             patch("sys.argv", ["statusline.py"]),
             patch.object(statusline, "_get_git_info", return_value={"branch": "main"}),
-            patch.object(statusline, "_get_usage", return_value=None),
             patch.object(statusline, "_resolve_currency", return_value="USD"),
             patch.object(statusline, "_get_session_cost", return_value=0.5),
             patch.object(statusline, "_get_daily_cost", return_value=1.0),
@@ -1927,7 +1790,6 @@ class TestMain:
             patch("sys.stdin") as mock_stdin,
             patch("sys.argv", ["statusline.py", "--icons", "nerd"]),
             patch.object(statusline, "_get_git_info", return_value=None),
-            patch.object(statusline, "_get_usage", return_value=None),
             patch.object(statusline, "_resolve_currency", return_value="USD"),
             patch.object(statusline, "_get_session_cost", return_value=None),
             patch.object(statusline, "_get_daily_cost", return_value=None),

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1151,9 +1151,9 @@ class TestSegRateCommon:
     def test_displays_rate_info(self) -> None:
         """レートリミット情報を表示する"""
         data = {
-            "_usage": {
+            "rate_limits": {
                 "five_hour": {
-                    "utilization": 45.0,
+                    "used_percentage": 45.0,
                     "resets_at": 1736951400.0,
                 },
             },
@@ -1171,8 +1171,8 @@ class TestSegRateCommon:
         assert "45%" in seg.text
         assert "14:30" in seg.text
 
-    def test_no_usage_returns_none(self) -> None:
-        """_usageがない場合はNone"""
+    def test_no_rate_limits_returns_none(self) -> None:
+        """rate_limitsがない場合はNone"""
         seg = statusline._seg_rate_common(
             {}, "five_hour", "5h", "\u23f0", statusline._format_reset_time_short
         )
@@ -1180,15 +1180,15 @@ class TestSegRateCommon:
 
     def test_no_bucket_returns_none(self) -> None:
         """指定のバケットがない場合はNone"""
-        data: dict[str, Any] = {"_usage": {}}
+        data: dict[str, Any] = {"rate_limits": {}}
         seg = statusline._seg_rate_common(
             data, "five_hour", "5h", "\u23f0", statusline._format_reset_time_short
         )
         assert seg is None
 
-    def test_missing_utilization_returns_none(self) -> None:
-        """utilizationがない場合はNone"""
-        data = {"_usage": {"five_hour": {"resets_at": "2025-01-15T14:30:00Z"}}}
+    def test_missing_used_percentage_returns_none(self) -> None:
+        """used_percentageがない場合はNone"""
+        data = {"rate_limits": {"five_hour": {"resets_at": "2025-01-15T14:30:00Z"}}}
         seg = statusline._seg_rate_common(
             data, "five_hour", "5h", "\u23f0", statusline._format_reset_time_short
         )
@@ -1197,9 +1197,9 @@ class TestSegRateCommon:
     def test_high_utilization_uses_red(self) -> None:
         """80%以上はREDカラー"""
         data = {
-            "_usage": {
+            "rate_limits": {
                 "five_hour": {
-                    "utilization": 90.0,
+                    "used_percentage": 90.0,
                     "resets_at": 1736951400.0,
                 },
             },
@@ -1215,12 +1215,12 @@ class TestSegRateCommon:
         assert seg is not None
         assert "\033[31m" in seg.text
 
-    def test_non_numeric_utilization_returns_none(self) -> None:
-        """数値変換できないutilizationの場合はNone"""
+    def test_non_numeric_used_percentage_returns_none(self) -> None:
+        """数値変換できないused_percentageの場合はNone"""
         data = {
-            "_usage": {
+            "rate_limits": {
                 "five_hour": {
-                    "utilization": "abc",
+                    "used_percentage": "abc",
                     "resets_at": "2025-01-15T14:30:00Z",
                 },
             },
@@ -1232,7 +1232,7 @@ class TestSegRateCommon:
 
     def test_missing_resets_at_returns_none(self) -> None:
         """resets_atがない場合はNone"""
-        data = {"_usage": {"five_hour": {"utilization": 45.0}}}
+        data = {"rate_limits": {"five_hour": {"used_percentage": 45.0}}}
         seg = statusline._seg_rate_common(
             data, "five_hour", "5h", "\u23f0", statusline._format_reset_time_short
         )
@@ -1245,9 +1245,9 @@ class TestSegRate5hAnd7d:
     def test_seg_rate_5h_returns_segment(self) -> None:
         """5hレートリミットセグメントを返す"""
         data = {
-            "_usage": {
+            "rate_limits": {
                 "five_hour": {
-                    "utilization": 30.0,
+                    "used_percentage": 30.0,
                     "resets_at": 1736951400.0,
                 },
             },
@@ -1261,9 +1261,9 @@ class TestSegRate5hAnd7d:
     def test_seg_rate_7d_returns_segment(self) -> None:
         """7dレートリミットセグメントを返す"""
         data = {
-            "_usage": {
+            "rate_limits": {
                 "seven_day": {
-                    "utilization": 50.0,
+                    "used_percentage": 50.0,
                     "resets_at": 1737331200.0,
                 },
             },

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -769,56 +769,37 @@ class TestOsc8Link:
         assert result == "\033]8;;https://example.com\a\033]8;;\a"
 
 
-class TestParseIsoToLocal:
-    """_parse_iso_to_local のテスト"""
-
-    def test_naive_datetime_treated_as_utc(self) -> None:
-        """タイムゾーンなしの入力はUTCとして扱われる"""
-        result = statusline._parse_iso_to_local("2025-01-15T14:30:00")
-        expected_utc = datetime(2025, 1, 15, 14, 30, tzinfo=UTC)
-        assert result.timestamp() == expected_utc.timestamp()
-
-    def test_aware_datetime_preserves_instant(self) -> None:
-        """タイムゾーン付きの入力は正しい時刻を保持する"""
-        result = statusline._parse_iso_to_local("2025-01-15T14:30:00+09:00")
-        # +09:00なのでUTCでは05:30
-        expected_utc = datetime(2025, 1, 15, 5, 30, tzinfo=UTC)
-        assert result.timestamp() == expected_utc.timestamp()
-
-    def test_result_has_timezone(self) -> None:
-        """結果にはタイムゾーン情報が付与される"""
-        result = statusline._parse_iso_to_local("2025-01-15T14:30:00Z")
-        assert result.tzinfo is not None
-
-    def test_utc_suffix(self) -> None:
-        """Z付きのISO文字列をパースできる"""
-        result = statusline._parse_iso_to_local("2025-06-01T00:00:00Z")
-        expected_utc = datetime(2025, 6, 1, 0, 0, tzinfo=UTC)
-        assert result.timestamp() == expected_utc.timestamp()
-
-
 class TestFormatResetTimeShort:
     """_format_reset_time_short のテスト"""
 
     def test_formats_as_h_mm(self) -> None:
         """H:MM形式でフォーマットされる"""
-        fixed_dt = datetime(2025, 1, 15, 14, 30, tzinfo=UTC)
-        with patch("statusline._parse_iso_to_local", return_value=fixed_dt):
-            result = statusline._format_reset_time_short("2025-01-15T14:30:00Z")
+        ts = datetime(2025, 1, 15, 14, 30, tzinfo=UTC).timestamp()
+        with patch("statusline.datetime") as mock_dt:
+            mock_dt.fromtimestamp.return_value.astimezone.return_value = datetime(
+                2025, 1, 15, 14, 30, tzinfo=UTC
+            )
+            result = statusline._format_reset_time_short(ts)
         assert result == "14:30"
 
     def test_no_zero_padding_hour(self) -> None:
         """時間は0埋めされない"""
-        fixed_dt = datetime(2025, 1, 15, 9, 5, tzinfo=UTC)
-        with patch("statusline._parse_iso_to_local", return_value=fixed_dt):
-            result = statusline._format_reset_time_short("2025-01-15T09:05:00Z")
+        ts = datetime(2025, 1, 15, 9, 5, tzinfo=UTC).timestamp()
+        with patch("statusline.datetime") as mock_dt:
+            mock_dt.fromtimestamp.return_value.astimezone.return_value = datetime(
+                2025, 1, 15, 9, 5, tzinfo=UTC
+            )
+            result = statusline._format_reset_time_short(ts)
         assert result == "9:05"
 
     def test_midnight(self) -> None:
         """0時の表示"""
-        fixed_dt = datetime(2025, 1, 15, 0, 0, tzinfo=UTC)
-        with patch("statusline._parse_iso_to_local", return_value=fixed_dt):
-            result = statusline._format_reset_time_short("2025-01-15T00:00:00Z")
+        ts = datetime(2025, 1, 15, 0, 0, tzinfo=UTC).timestamp()
+        with patch("statusline.datetime") as mock_dt:
+            mock_dt.fromtimestamp.return_value.astimezone.return_value = datetime(
+                2025, 1, 15, 0, 0, tzinfo=UTC
+            )
+            result = statusline._format_reset_time_short(ts)
         assert result == "0:00"
 
 
@@ -827,16 +808,22 @@ class TestFormatResetDate:
 
     def test_formats_as_m_d_h_mm(self) -> None:
         """M/D H:MM形式でフォーマットされる"""
-        fixed_dt = datetime(2025, 1, 15, 14, 30, tzinfo=UTC)
-        with patch("statusline._parse_iso_to_local", return_value=fixed_dt):
-            result = statusline._format_reset_date("2025-01-15T14:30:00Z")
+        ts = datetime(2025, 1, 15, 14, 30, tzinfo=UTC).timestamp()
+        with patch("statusline.datetime") as mock_dt:
+            mock_dt.fromtimestamp.return_value.astimezone.return_value = datetime(
+                2025, 1, 15, 14, 30, tzinfo=UTC
+            )
+            result = statusline._format_reset_date(ts)
         assert result == "1/15 14:30"
 
     def test_no_zero_padding(self) -> None:
         """月・日・時は0埋めされない"""
-        fixed_dt = datetime(2025, 3, 5, 9, 5, tzinfo=UTC)
-        with patch("statusline._parse_iso_to_local", return_value=fixed_dt):
-            result = statusline._format_reset_date("2025-03-05T09:05:00Z")
+        ts = datetime(2025, 3, 5, 9, 5, tzinfo=UTC).timestamp()
+        with patch("statusline.datetime") as mock_dt:
+            mock_dt.fromtimestamp.return_value.astimezone.return_value = datetime(
+                2025, 3, 5, 9, 5, tzinfo=UTC
+            )
+            result = statusline._format_reset_date(ts)
         assert result == "3/5 9:05"
 
 
@@ -1167,7 +1154,7 @@ class TestSegRateCommon:
             "_usage": {
                 "five_hour": {
                     "utilization": 45.0,
-                    "resets_at": "2025-01-15T14:30:00Z",
+                    "resets_at": 1736951400.0,
                 },
             },
         }
@@ -1213,7 +1200,7 @@ class TestSegRateCommon:
             "_usage": {
                 "five_hour": {
                     "utilization": 90.0,
-                    "resets_at": "2025-01-15T14:30:00Z",
+                    "resets_at": 1736951400.0,
                 },
             },
         }
@@ -1261,7 +1248,7 @@ class TestSegRate5hAnd7d:
             "_usage": {
                 "five_hour": {
                     "utilization": 30.0,
-                    "resets_at": "2025-01-15T14:30:00Z",
+                    "resets_at": 1736951400.0,
                 },
             },
         }
@@ -1277,7 +1264,7 @@ class TestSegRate5hAnd7d:
             "_usage": {
                 "seven_day": {
                     "utilization": 50.0,
-                    "resets_at": "2025-01-20T00:00:00Z",
+                    "resets_at": 1737331200.0,
                 },
             },
         }


### PR DESCRIPTION
## 概要

Claude Code v2.1.80以降、statuslineフックのstdinに `rate_limits` フィールドが直接含まれるようになった。
従来のOAuth API経由のレートリミット取得を廃止し、stdinデータを直接利用するよう変更する。

## 変更内容

- `_format_reset_time_short` / `_format_reset_date` をISO 8601文字列からUnixタイムスタンプ(float)受け取りに変更
- `_seg_rate_common` のデータソースを `data["_usage"]` から `data["rate_limits"]` に変更
- フィールド名を `utilization` から `used_percentage` に変更
- OAuth API関連コードを全削除 (`_get_oauth_token`, `_fetch_usage`, `_get_usage`, 関連定数)
- `main()` から `_get_usage()` 呼び出しを除去
- テストを全て新形式に更新

## 効果

- 外部API呼び出しの排除によるレイテンシ削減
- OAuth認証・キャッシュ管理の複雑さを排除
- コード量: -317行 / +81行 (net -236行)

## テスト

- 202テスト全PASS
- pyright 0 errors
- カバレッジ 99.33%